### PR TITLE
✨ Add timestamp to the url to make it volatile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
 RUN cd /usr/local/bin && curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint && chmod +x ktlint
 
 RUN npm install -g danger@10.2.1
-RUN curl -s https://raw.githubusercontent.com/danger/kotlin/master/scripts/install.sh | bash && \
+RUN curl -s https://raw.githubusercontent.com/danger/kotlin/master/scripts/install.sh?tms=$(date +%s) | bash && \
     rm -r /root/.gradle
 
 ENV PATH=$PATH:/usr/local/kotlinc/bin:/opt/gradle/gradle-5.6.2/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ RUN apt-get update && apt-get install -y \
 RUN cd /usr/local/bin && curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint && chmod +x ktlint
 
 RUN npm install -g danger@10.2.1
-# if we want to force step to build danger-kotlin we need to change following property
+# Currently danger-kotlin has sparse releases and we are in the phase of discovery of this technology.
+# For that reason we don't use their versions and we build the binaries from the source code. Docker 
+# caches this RUN command because it did not change. which makes it impossible to rebuild the image without 
+# pruning the cache. To be able to easily force this commant to rebuild, we add this artificial dummy property.
+# Everytime we want rebuild the image we need to change value of this property.
 ARG dummy_version=1
 RUN curl -s https://raw.githubusercontent.com/danger/kotlin/master/scripts/install.sh?dummy=$(dummy_version) | bash && \
     rm -r /root/.gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && apt-get install -y \
 RUN cd /usr/local/bin && curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint && chmod +x ktlint
 
 RUN npm install -g danger@10.2.1
-RUN curl -s https://raw.githubusercontent.com/danger/kotlin/master/scripts/install.sh?tms=$(date +%s) | bash && \
+# if we want to force step to build danger-kotlin we need to change following property
+ARG dummy_version=1
+RUN curl -s https://raw.githubusercontent.com/danger/kotlin/master/scripts/install.sh?dummy=$(dummy_version) | bash && \
     rm -r /root/.gradle
 
 ENV PATH=$PATH:/usr/local/kotlinc/bin:/opt/gradle/gradle-5.6.2/bin


### PR DESCRIPTION
To prevent caching mechanism of docker build we add timestamp
to install script url

Related: #noref