### PR TITLE
♻️  Do not use install script from repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,21 @@ RUN apt-get update && apt-get install -y \
 RUN cd /usr/local/bin && curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.34.2/ktlint && chmod +x ktlint
 
 RUN npm install -g danger@10.2.1
-# Currently danger-kotlin has sparse releases and we are in the phase of discovery of this technology.
-# For that reason we don't use their versions and we build the binaries from the source code. Docker 
-# caches this RUN command because it did not change. which makes it impossible to rebuild the image without 
-# pruning the cache. To be able to easily force this commant to rebuild, we add this artificial dummy property.
-# Everytime we want rebuild the image we need to change value of this property.
-ARG dummy_version=0
-RUN curl -s https://raw.githubusercontent.com/danger/kotlin/d06e9bc166b26a3847d6a17677950e2d23f9c252/scripts/install.sh?dummy=$dummy_version | bash && \
-    rm -r /root/.gradle
+
+RUN curl -o kotlin-compiler.zip -L https://github.com/JetBrains/kotlin/releases/download/v1.4.10/kotlin-compiler-1.4.10.zip && \
+    unzip -d /usr/local/ kotlin-compiler.zip && \
+    rm -rf kotlin-compiler.zip
+
+RUN curl -o gradle.zip -L https://downloads.gradle-dn.com/distributions/gradle-5.6.2-bin.zip && \
+    mkdir /opt/gradle && \
+    unzip -d /opt/gradle gradle.zip && \
+    rm -rf gradle.zip
+
+RUN git clone https://github.com/danger/kotlin.git _danger-kotlin && \
+    cd _danger-kotlin && git checkout 0.7.1 && \
+    make install  && \
+    cd ..  && \
+    rm -rf _danger-kotlin
 
 ENV PATH=$PATH:/usr/local/kotlinc/bin:/opt/gradle/gradle-5.6.2/bin
 


### PR DESCRIPTION
Install script was pointing to the current master branch
which may not be stable. Take required steps from the install
script and move them to Dockerfile and fix version to 0.7.1 through
tag.

Related: #53330